### PR TITLE
Fix docs for default `split` function behavior

### DIFF
--- a/docs/src/lecture_01/strings.md
+++ b/docs/src/lecture_01/strings.md
@@ -322,7 +322,7 @@ julia> split(str)
  "language!"
 ```
 
-By default, the function splits the given string based on spaces. This can be changed by defining a delimiter.
+By default, the function splits the given string based on whitespace characters. This can be changed by defining a delimiter.
 
 ```jldoctest joins
 julia> split(str, " a ")


### PR DESCRIPTION
Fix docs for default `split` function behaviour